### PR TITLE
Add recharge-rate calculator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ specifically for use with the Slack adapter.
 * Report level requirements
 * List requirements for all levels
 * Store badge information for players
+* Calculate recharge rate and max distance for AP level
 * *much more to come...*
 
 ## Installation
@@ -72,3 +73,17 @@ Badges can be removed one by one.
 Gives you a link to the Ingress Intel map based on Google Maps search.
 
 `hubot intelmap soho ny`
+
+### Calculate max recharge distance
+
+Calculate maximum distance from which an agent can recharge, based on agent level.
+
+`hubot recharge distance [level]`
+
+### Calculate recharge rate/percentage
+
+Calculate recharge efficiency for an agent, based on agent level and distance.
+
+`hubot recharge rate [level] [distance]`
+
+Note: The distance parameter defaults to km, but it can also convert imperial units, e.g. `hubot recharge rate 11 450 miles`

--- a/src/recharge-rate.coffee
+++ b/src/recharge-rate.coffee
@@ -1,0 +1,52 @@
+# Description:
+#   Calculate Recharge Rate in Ingress.
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   hubot recharge distance|max [level]
+#   hubot recharge rate|efficiency|percent [level] [distance]
+#
+# Author:
+#   impleri
+
+precision = 10 # each zero = 1 decimal place
+
+calculateEfficiency = (distance, level = 8) ->
+    efficiency = 100 - (distance / (5 * level))
+    efficiency = 0 if efficiency < 50
+    round efficiency
+
+calculateDistance = (level = 8) ->
+    250 * level
+
+convertToKm = (distance, unit = "km") ->
+    switch unit
+        when "m", "meters" then divisor = 1000
+        when "ft", "foot", "feet" then divisor = 3280.84
+        when "yd", "yard", "yards" then divisor = 1093.61
+        when "mi", "miles" then divisor = 0.621371
+        else divisor = 1
+    distance/divisor
+
+round = (number) ->
+    Math.round(number*precision)/precision
+
+module.exports = (robot) ->
+  robot.respond /recharge\s+(max|distance)\s+([0-9]{1,2})/i, (msg) ->
+    level = +msg.match[2]
+    distance = calculateDistance level
+    msg.reply "A level #{level} agent can recharge up to #{distance} km away."
+
+  robot.respond /recharge\s+(efficiency|rate|percent)\s+([0-9]{1,2})\s+([0-9\.]+)\s*([a-z]+)?/i, (msg) ->
+    level = +msg.match[2]
+    qty = +msg.match[3]
+    distance = round convertToKm qty, msg.match[4]
+    rate = calculateEfficiency distance, level
+    response = "A level #{level} agent cannot recharge from #{distance} km away."
+    response = "A level #{level} agent can recharge from #{distance} km away at #{rate}%." if rate > 0
+    msg.reply response

--- a/test/ingress_test.coffee
+++ b/test/ingress_test.coffee
@@ -64,6 +64,7 @@ describe 'ingress', ->
                 
 
   require('../src/ingress')(robot)
+  require("../src/recharge-rate")(robot)
 
   describe 'respond listener', ->
 
@@ -171,3 +172,26 @@ describe 'ingress', ->
         @robot.googleGeocodeKey = httpResponseKey.expectedKey
         @robot.respond.args[6][1](@msg)
         expect(@msg.reply).to.have.been.calledWith("https://www.ingress.com/intel?ll=#{httpResponseKey.lat},#{httpResponseKey.long}&z=16")
+
+    describe 'recharge distance listener',->
+
+      it 'registers "recharge distance" listener', ->
+        expect(@robot.respond).to.have.been.calledWith /recharge\s+(max|distance)\s+([0-9]{1,2})/i
+
+      it 'registers "recharge rate" listener', ->
+        expect(@robot.respond).to.have.been.calledWith /recharge\s+(efficiency|rate|percent)\s+([0-9]{1,2})\s+([0-9\.]+)\s*([a-z]+)?/i
+
+      it 'responds to "recharge distance"', ->
+        @msg.match = [0, 'max', '8']
+        @robot.respond.args[7][1](@msg)
+        expect(@msg.reply).to.have.been.calledWith('A level 8 agent can recharge up to 2000 km away.')
+
+      it 'responds to potential "recharge rate"', ->
+        @msg.match = [0, 'rate', '8', '1000']
+        @robot.respond.args[8][1](@msg)
+        expect(@msg.reply).to.have.been.calledWith('A level 8 agent can recharge from 1000 km away at 75%.')
+
+      it 'responds to out-of-range "recharge rate"', ->
+        @msg.match = [0, 'rate', '8', '3000']
+        @robot.respond.args[8][1](@msg)
+        expect(@msg.reply).to.have.been.calledWith('A level 8 agent cannot recharge from 3000 km away.')


### PR DESCRIPTION
This PR adds recharge rate calculation. Originally, this code was in hubot-recharge, but moving it here seems more logical.
