### PR TITLE
Add support for setting timezone names in addition to offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ Create a new project for your hubot in the developer console, unless you
 have one already. Enable "Geocoding API" under "_APIs_" and then 
 create a new key under "_Credentials_".
 
-`HUBOT_CYCLE_TIME_FMT` - Optionally ovveride the display format for times (see Moment.js). Default is "ddd hA" (e.g. "Sun 10pm")
-`HUBOT_CYCLE_TZ_OFFSET` - Optionally set the timezone offset (see Moment.js). Defaults to the server instance's offset.
+`HUBOT_CYCLE_TIME_FMT` - Optionally ovveride the display format for times (see Moment-timezone.js). Default is "ddd hA" (e.g. "Sun 10pm")
+
+`HUBOT_CYCLE_TZ_NAME` - Optionally set the timezone name (e.g. 'EST' see Moment-timezone.js). This wins when set.
+
+`HUBOT_CYCLE_TZ_OFFSET` - Optionally set the timezone offset (e.g. '-05:00', see Moment.js). Defaults to the server instance's offset. This is used when `HUBOT_CYCLE_TZ_NAME` is not provided.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.6",
-    "moment": "~2.8"
+    "moment-timezone": "~0.2"
   },
   "devDependencies": {
     "mocha": "*",

--- a/src/cycle-times.coffee
+++ b/src/cycle-times.coffee
@@ -2,51 +2,63 @@
 #   Calculate Speticycle times.
 #
 # Dependencies:
-#   Moment.js
+#   Moment-timezone.js
 #
 # Configuration:
-#   HUBOT_CYCLE_TIME_FMT: set the display format for times (uses Moment.js)
-#   HUBOT_CYCLE_TZ_OFFSET: set the timezone offset (uses Moment.js)
+#   HUBOT_CYCLE_TIME_FMT: set the display format for times (uses Moment-timezone.js)
+#   HUBOT_CYCLE_TZ_OFFSET: set the timezone offset (uses Moment-timezone.js)
+#   HUBOT_CYCLE_TZ_NAME: set the timezone name (uses Moment-timezone.js) (name wins if set)
 #
 # Commands:
 #   hubot septicycle|cycle [count]
 #   hubot checkpoint|cp [count]
 #   hubot cycle offset
 #   hubot cycle set offset [offset]
+#   hubot cycle set offsetname [offset name]
 #
 # Author:
 #   impleri
 
-moment = require "moment"
+moment = require "moment-timezone"
 
 # Environment variables
 timeFormat = process.env.HUBOT_CYCLE_TIME_FMT or "ddd hA"
-tzOffset = process.env.HUBOT_CYCLE_TZ_OFFSET or moment().zone()
+tzOffset = process.env.HUBOT_CYCLE_TZ_OFFSET or moment().format("Z")
+tzName = process.env.HUBOT_CYCLE_TZ_NAME
 
 # Basic variables
 checkpoint = 5*60*60 # 5 hours per checkpoint
 cycle = checkpoint * 35 # 35 checkpoints per cycle
 seconds = 1000
 
+formatTime = (time) ->
+    m = if tzName then moment(time).tz(tzName) else moment(time).zone(tzOffset)
+    m.format " #{timeFormat}"
+
 getNextCycle = (next = 1) ->
     now = new Date().getTime()
     start = seconds * cycle * Math.floor now / (cycle * seconds)
     time = start + cycle * seconds * next
-    moment(time).zone(tzOffset).format " #{timeFormat}"
+    formatTime(time)
 
 getNextCheckpoint = (next = 1) ->
     now = new Date().getTime()
     start = checkpoint * seconds * Math.floor now / (checkpoint * seconds)
     time = start + checkpoint * seconds * next
-    moment(time).zone(tzOffset).format " #{timeFormat}"
+    formatTime(time)
 
 module.exports = (robot) ->
   robot.respond /cycle offset/i, (msg) ->
-    msg.send "Current timezone offset is #{tzOffset} minutes."
+    offset = tzName or tzOffset
+    msg.send "Current timezone offset is #{offset}."
 
   robot.respond /cycle set offset (.*)/i, (msg) ->
     tzOffset = msg.match[1]
     msg.send "Timezone offset is set to #{tzOffset}. I hope you know what you are doing."
+
+  robot.respond /cycle set offsetname (.*)/i, (msg) ->
+    tzOffset = msg.match[1]
+    msg.send "Timezone offset name is set to #{tzName}. I hope you know what you are doing."
 
   robot.respond /(septi)?cycle\s*([0-9])?/i, (msg) ->
     count = +msg.match[2]

--- a/test/cycle-times-coffee.coffee
+++ b/test/cycle-times-coffee.coffee
@@ -34,3 +34,6 @@ describe 'ingress: cycle times', ->
 
   it 'registers "cycle set offset" listener', ->
     expect(@robot.respond).to.have.been.calledWith /cycle set offset (.*)/i
+
+  it 'registers "cycle set offsetname" listener', ->
+    expect(@robot.respond).to.have.been.calledWith /cycle set offsetname (.*)/i


### PR DESCRIPTION
When I originally tried to deploy cycle calculator, I attempted to use timezone name instead of offset. This obviously didn't work. After configuring offset and including `Z` in the formatter, the feedback I got was that people wanted to see time with `EST` opposed to `-05:00`. Additionally, the offset command response was awkward when the offset was configured via env variable. e.g. `Current timezone offset is -04:00 minutes.`

I changed the dependency from moment.js to moment-timezone.js and added support for configuring `HUBOT_CYCLE_TZ_NAME` in addition to `HUBOT_CYCLE_TZ_OFFSET`. Name wins if both are provided. If none is provided, the server offset is used. This change allows you to use `z` in the time formatter. Another benefit to configuring timezone name is that DST changes are automatically handled by moment-timezone opposed to requiring someone to change the env variable manually.

With `HUBOT_CYCLE_TZ_NAME="EST"` and `HUBOT_CYCLE_TIME_FMT="ddd hA z"`

> Current timezone offset is EST.
> The next 1 cycle(s) occur at:  Mon 6PM EST.

With `HUBOT_CYCLE_TZ_NAME` unset and `HUBOT_CYCLE_TIME_FMT="ddd hA z"`

> Current timezone offset is +00:00.
> The next 1 cycle(s) occur at:  Mon 11PM UTC.

With `HUBOT_CYCLE_TZ_OFFSET="-01:00"`, `HUBOT_CYCLE_TZ_NAME` unset and `HUBOT_CYCLE_TIME_FMT="ddd hA"`

> Current timezone offset is -01:00.
> The next 1 cycle(s) occur at:  Mon 10PM.
