### PR TITLE
Badge multiplier

### DIFF
--- a/src/levels.coffee
+++ b/src/levels.coffee
@@ -95,20 +95,20 @@ levels =
       black: 2
 
 module.exports = (robot) ->
-  sayBadges = (a) ->
-    badgeReq = for kind, amt of a
-      Array(amt+1).join ":#{kind}:"
+  quantifyBadges = (a) ->
+    for kind, n of a
+      ":#{kind}:#{if n > 1 then '×' + n else ''}"
 
   robot.respond /AP\s+(?:to|(?:un)?til)\s+L?(\d\d?)/i, (msg) ->
     [lv, lvl] = [msg.match[1], levels[msg.match[1]]]
     if lvl.badges?
-      badgeReq = sayBadges lvl.badges
+      badgeReq = quantifyBadges lvl.badges
     msg.reply "You need #{lvl.ap} AP#{if badgeReq? then ' ' + badgeReq.join ' ' else ''}
  to reach L#{lv}#{if lv > 15 then ' (hang in there!)' else ''}"
 
   robot.respond /AP all/i, (msg) ->
     lvls = for lv, lvl of levels
       if lvl.badges?
-        badgeReq = sayBadges lvl.badges
+        badgeReq = quantifyBadges lvl.badges
       "\nL#{lv} = #{lvl.ap} AP#{if badgeReq? then ' ' + badgeReq.join ' ' else ''}"
     msg.send lvls.join ""

--- a/src/levels.coffee
+++ b/src/levels.coffee
@@ -99,7 +99,7 @@ module.exports = (robot) ->
     badgeReq = for kind, amt of a
       Array(amt+1).join ":#{kind}:"
 
-  robot.respond /AP\s+(?:to|(?:un)?til)\s+L?(\d{1,2})/i, (msg) ->
+  robot.respond /AP\s+(?:to|(?:un)?til)\s+L?(\d\d?)/i, (msg) ->
     [lv, lvl] = [msg.match[1], levels[msg.match[1]]]
     if lvl.badges?
       badgeReq = sayBadges lvl.badges

--- a/test/levels-test.coffee
+++ b/test/levels-test.coffee
@@ -14,7 +14,7 @@ describe 'ingress: levels', ->
   require('../src/levels')(robot)
 
   it 'registers AP per level listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/AP\s+(?:to|(?:un)?til)\s+L?(\d{1,2})/i)
+    expect(@robot.respond).to.have.been.calledWith(/AP\s+(?:to|(?:un)?til)\s+L?(\d\d?)/i)
 
   it 'registers AP for all levels listener', ->
     expect(@robot.respond).to.have.been.calledWith(/AP all/i)

--- a/test/levels-test.coffee
+++ b/test/levels-test.coffee
@@ -10,6 +10,8 @@ describe 'ingress: levels', ->
 
   beforeEach ->
     @robot = robot
+    @msg =
+      reply: sinon.spy()
 
   require('../src/levels')(robot)
 
@@ -18,3 +20,8 @@ describe 'ingress: levels', ->
 
   it 'registers AP for all levels listener', ->
     expect(@robot.respond).to.have.been.calledWith(/AP all/i)
+
+  it 'responds to AP query', ->
+    @msg.match = [null, 3]
+    @robot.respond.args[0][1](@msg)
+    expect(@msg.reply).to.have.been.calledWithMatch(/You need \d+ AP.*? to reach L\d\d?/)


### PR DESCRIPTION
Makes the AP responses less spammy by using a multiplier symbol (`×`) instead of repeating the badge types several times.

Closes #13 