### PR TITLE
Adding "intel map" to regex in intel-map.coffee

### DIFF
--- a/src/intel-map.coffee
+++ b/src/intel-map.coffee
@@ -40,6 +40,6 @@ module.exports = (robot) ->
     url = intelmapUrl coords
     msg.reply url
 
-  robot.respond /(intelmap)(?: for)?\s(.*)/i, (msg) ->
+  robot.respond /(intelmap|intel map|intel)(?: for)?\s(.*)/i, (msg) ->
     location = msg.match[2]
     lookupLatLong msg, location, sendIntelLink

--- a/src/intel-map.coffee
+++ b/src/intel-map.coffee
@@ -40,6 +40,6 @@ module.exports = (robot) ->
     url = intelmapUrl coords
     msg.reply url
 
-  robot.respond /(intelmap|intel map|intel)(?: for)?\s(.*)/i, (msg) ->
+  robot.respond /(intelmap|intel map)(?: for)?\s(.*)/i, (msg) ->
     location = msg.match[2]
     lookupLatLong msg, location, sendIntelLink


### PR DESCRIPTION
Added the phrase "intel map" to the regex hubot will listen for. Per https://github.com/hubot-scripts/hubot-ingress/issues/21 