### PR TITLE
Updating cycle offset names to really use timezone names and new momentjs methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ specifically for use with the Slack adapter.
 Then add `"hubot-ingress"` to `external-scripts.json`
 
 Go to the custom emojis page of your Slack team. Upload each of the images from
-the `badges/` subfolder, naming them the same as their filename (without the extension).
+the `badges/` subfolder, naming them the same as their filename (without the
+extension).
 These emoji will be used by Hubot.
 
 ## Configuration
@@ -38,17 +39,23 @@ Create a new project for your hubot in the developer console, unless you
 have one already. Enable "Geocoding API" under "_APIs_" and then
 create a new key under "_Credentials_".
 
-`HUBOT_CYCLE_TIME_FMT` - Optionally ovveride the display format for times (see Moment-timezone.js). Default is "ddd hA" (e.g. "Sun 10pm")
+`HUBOT_CYCLE_TIME_FMT` - Optionally ovveride the display format for times (see
+Moment-timezone.js). Default is "ddd hA" (e.g. "Sun 10pm")
 
-`HUBOT_CYCLE_TZ_NAME` - Optionally set the timezone name (e.g. 'America/Chicago' see Moment-timezone.js). This wins when set.
+`HUBOT_CYCLE_TZ_NAME` - Optionally set the timezone name (e.g. 'America/Chicago';
+see [TZ name list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for names to use.).
+This overrides `HUBOT_CYCLE_TZ_OFFSET` if both are set.
 
-`HUBOT_CYCLE_TZ_OFFSET` - Optionally set the timezone offset (e.g. '-05:00', see Moment.js). Defaults to the server instance's offset. This is used when `HUBOT_CYCLE_TZ_NAME` is not provided.
+`HUBOT_CYCLE_TZ_OFFSET` - Optionally set the timezone offset (e.g. '-05:00',
+see [Moment.js](http://momentjs.com/docs/#/manipulating/timezone-offset/)).
+Defaults to the server instance's offset. This is used when
+`HUBOT_CYCLE_TZ_NAME` is not provided.
 
 ### Slack
 
-In order for the badge images to be seen on Slack, you must manually upload each
-one as an emoji with the appropriate name. Each image is conveniently named
-exactly how the emoji name should appear (leave off the .png of course).
+In order for the badge images to be seen on Slack, you must manually upload
+each one as an emoji with the appropriate name. Each image is conveniently
+named exactly how the emoji name should appear (leave off the .png of course).
 
 Go to <yourslackdomain>.slack.com/admin/emoji to configure emoji.
 
@@ -68,10 +75,11 @@ Show the AP/badge requirements for every level.
 
 ### Add badges
 
-Badges can be added one by one or multiples at a time, and can be added for other players.
-Badges that have levels end with a number representing that level (1=bronze, 2=silver, etc).
-When a badge is added that is the same as an existing badge (hacker5 vs hacker1, for example),
-then the new badge will replace the existing badge.
+Badges can be added one by one or multiples at a time, and can be added for
+other players. Badges that have levels end with a number representing that
+level (1=bronze, 2=silver, etc). When a badge is added that is the same as an
+existing badge (hacker5 vs hacker1, for example), then the new badge will
+replace the existing badge.
 
 `hubot I have the hacker3, founder badges`
 
@@ -91,7 +99,8 @@ Gives you a link to the Ingress Intel map based on Google Maps search.
 
 ### Calculate max recharge distance
 
-Calculate maximum distance from which an agent can recharge, based on agent level.
+Calculate maximum distance from which an agent can recharge, based on agent
+level.
 
 `hubot recharge distance [level]`
 
@@ -101,17 +110,20 @@ Calculate recharge efficiency for an agent, based on agent level and distance.
 
 `hubot recharge rate [level] [distance]`
 
-Note: The distance parameter defaults to km, but it can also convert imperial units, e.g. `hubot recharge rate 11 450 miles`
+Note: The distance parameter defaults to km, but it can also convert imperial
+units, e.g. `hubot recharge rate 11 450 miles`
 
 ### Get Septicycle times
 
-Calculate the next septicycle start. Optionally provide a number X to get the next X start times.
+Calculate the next septicycle start. Optionally provide a number X to get the
+next X start times.
 
 `hubot septicycle|cycle [count]`
 
 ### Get Checkpoint times
 
-Calculate the next checkpoint start. Optionally provide a number X to get the next X start times.
+Calculate the next checkpoint start. Optionally provide a number X to get the
+next X start times.
 
 `hubot checkpoint|cp [count]`
 
@@ -123,14 +135,14 @@ Returns the current configured timezone offset.
 
 ### Set Timezone Offset
 
-Set the timezone offset. See [Moment.js](http://momentjs.com/docs/#/manipulating/timezone-offset/) for how to configure this.
+Temporarily sets the timezone offset. See [Moment.js](http://momentjs.com/docs/#/manipulating/timezone-offset/)
+for how to configure this.
 
 `hubot cycle set offset [offset]`
 
 ### Set Timezone Offset By Name
 
-Set the timezone offset by name. See [TZ name list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for names to use.
+Temporarily sets the timezone offset by name. See [TZ name list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+for names to use.
 
 `hubot cycle set offsetname [offset-name]`
-
-

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ create a new key under "_Credentials_".
 
 `HUBOT_CYCLE_TIME_FMT` - Optionally ovveride the display format for times (see Moment-timezone.js). Default is "ddd hA" (e.g. "Sun 10pm")
 
-`HUBOT_CYCLE_TZ_NAME` - Optionally set the timezone name (e.g. 'EST' see Moment-timezone.js). This wins when set.
+`HUBOT_CYCLE_TZ_NAME` - Optionally set the timezone name (e.g. 'America/Chicago' see Moment-timezone.js). This wins when set.
 
 `HUBOT_CYCLE_TZ_OFFSET` - Optionally set the timezone offset (e.g. '-05:00', see Moment.js). Defaults to the server instance's offset. This is used when `HUBOT_CYCLE_TZ_NAME` is not provided.
 
@@ -126,3 +126,11 @@ Returns the current configured timezone offset.
 Set the timezone offset. See [Moment.js](http://momentjs.com/docs/#/manipulating/timezone-offset/) for how to configure this.
 
 `hubot cycle set offset [offset]`
+
+### Set Timezone Offset By Name
+
+Set the timezone offset by name. See [TZ name list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for names to use.
+
+`hubot cycle set offsetname [offset-name]`
+
+

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.6",
-    "moment-timezone": "~0.2"
+    "moment-timezone": "~0.3"
   },
   "devDependencies": {
     "mocha": "*",

--- a/src/cycle-times.coffee
+++ b/src/cycle-times.coffee
@@ -32,20 +32,20 @@ cycle = checkpoint * 35 # 35 checkpoints per cycle
 seconds = 1000
 
 formatTime = (time) ->
-    m = if tzName then moment(time).tz(tzName) else moment(time).zone(tzOffset)
+    m = if tzName then moment(time).tz(tzName) else moment(time).utcOffset(tzOffset)
     m.format " #{timeFormat}"
 
 getNextCycle = (next = 1) ->
     now = new Date().getTime()
     start = seconds * cycle * Math.floor now / (cycle * seconds)
     time = start + cycle * seconds * next
-    formatTime(time)
+    formatTime time
 
 getNextCheckpoint = (next = 1) ->
     now = new Date().getTime()
     start = checkpoint * seconds * Math.floor now / (checkpoint * seconds)
     time = start + checkpoint * seconds * next
-    formatTime(time)
+    formatTime time
 
 module.exports = (robot) ->
   robot.respond /cycle offset/i, (msg) ->
@@ -57,10 +57,10 @@ module.exports = (robot) ->
     msg.send "Timezone offset is set to #{tzOffset}. I hope you know what you are doing."
 
   robot.respond /cycle set offsetname (.*)/i, (msg) ->
-    tzOffset = msg.match[1]
+    tzName = msg.match[1]
     msg.send "Timezone offset name is set to #{tzName}. I hope you know what you are doing."
 
-  robot.respond /(septi)?cycle\s*([0-9])?/i, (msg) ->
+  robot.respond /(septi)?cycle\s*([0-9])?$/i, (msg) ->
     count = +msg.match[2]
     count = 1 unless count > 1
     times = []

--- a/test/cycle-times-coffee.coffee
+++ b/test/cycle-times-coffee.coffee
@@ -24,7 +24,7 @@ describe 'ingress: cycle times', ->
   require("../src/cycle-times")(robot)
 
   it 'registers "cycle" listener', ->
-    expect(@robot.respond).to.have.been.calledWith /(septi)?cycle\s*([0-9])?/i
+    expect(@robot.respond).to.have.been.calledWith /(septi)?cycle\s*([0-9])?$/i
 
   it 'registers "checkpoint" listener', ->
     expect(@robot.respond).to.have.been.calledWith /c(heck)?p(oint)?\s*([0-9])?/i


### PR DESCRIPTION
Previously, seting a tzName via hubot failed because it was setting tzOffset (erroneously). This fixes that along with deprecation warning from momentjs for using moment.zone()