### PR TITLE
Add Address to intelmap response

### DIFF
--- a/src/intel-map.coffee
+++ b/src/intel-map.coffee
@@ -10,8 +10,6 @@
 # Commands:
 #   hubot intelmap for <search>
 #
-# Author:
-#   therealklanni
 
 module.exports = (robot) ->
   # Setting this on robot so that it can be overridden in test. Is there a better way?
@@ -27,18 +25,21 @@ module.exports = (robot) ->
       .get() (err, res, body) ->
         try
           body = JSON.parse body
-          coords = body.results[0].geometry.location
+          result =
+            address: body.results[0].formatted_address
+            coords: body.results[0].geometry.location
         catch err
           err = "Could not find #{location}"
           return cb(err, msg, null)
-        cb(err, msg, coords)
+        cb(err, msg, result)
 
-  intelmapUrl = (coords) ->
-    return "https://www.ingress.com/intel?ll=" + encodeURIComponent(coords.lat) + "," + encodeURIComponent(coords.lng) + "&z=16"
-  sendIntelLink = (err, msg, coords) ->
+  intelmapUrl = (result) ->
+    return result.address + "\nhttps://www.ingress.com/intel?ll=" + encodeURIComponent(result.coords.lat) + "," + encodeURIComponent(result.coords.lng) + "&z=16"
+
+  sendIntelLink = (err, msg, result) ->
     return msg.send err if err
-    url = intelmapUrl coords
-    msg.reply url
+    url = intelmapUrl result
+    msg.send url
 
   robot.respond /(intelmap|intel map)(?: for)?\s(.*)/i, (msg) ->
     location = msg.match[2]

--- a/test/intel-map-test.coffee
+++ b/test/intel-map-test.coffee
@@ -25,12 +25,14 @@ describe 'ingress: intelmap', ->
   parseError =
     location: "parse_error"
   httpResponseNoKey =
-    body: '{"results": [{ "geometry": { "location": { "lat": "LatNoKey", "lng": "LongNoKey" } } }]}'
+    body: '{"results": [{ "formatted_address" : "Some, Formatted, Address", "geometry": { "location": { "lat": "LatNoKey", "lng": "LongNoKey" } } }]}'
+    formatted_address: "Some, Formatted, Address"
     lat: "LatNoKey"
     long: "LongNoKey"
   httpResponseKey =
     expectedKey: 'ExpectedGeocodeKey'
-    body: '{"results": [{ "geometry": { "location": { "lat": "LatKey", "lng": "LongKey" } } }]}'
+    body: '{"results": [{ "formatted_address" : "Some, Formatted, Address", "geometry": { "location": { "lat": "LatKey", "lng": "LongKey" } } }]}'
+    formatted_address: "Some, Formatted, Address"
     lat: "LatKey"
     long: "LongKey"
 
@@ -78,10 +80,10 @@ describe 'ingress: intelmap', ->
   it 'responds to intelmap with url when no Google Geocode API key set', ->
     @msg.match = [0, 'intelmap', 'boston ma']
     @robot.respond.args[0][1](@msg)
-    expect(@msg.reply).to.have.been.calledWith("https://www.ingress.com/intel?ll=#{httpResponseNoKey.lat},#{httpResponseNoKey.long}&z=16")
+    expect(@msg.send).to.have.been.calledWith("#{httpResponseKey.formatted_address}\nhttps://www.ingress.com/intel?ll=#{httpResponseNoKey.lat},#{httpResponseNoKey.long}&z=16")
 
   it 'responds to intelmap with url when Google Geocode API key set', ->
     @msg.match = [0, 'intelmap', 'boston ma']
     @robot.googleGeocodeKey = httpResponseKey.expectedKey
     @robot.respond.args[0][1](@msg)
-    expect(@msg.reply).to.have.been.calledWith("https://www.ingress.com/intel?ll=#{httpResponseKey.lat},#{httpResponseKey.long}&z=16")
+    expect(@msg.send).to.have.been.calledWith("#{httpResponseKey.formatted_address}\nhttps://www.ingress.com/intel?ll=#{httpResponseKey.lat},#{httpResponseKey.long}&z=16")


### PR DESCRIPTION
Unfortunately the google geocode api is unable to read minds and sometimes responds with an unexpected result. 

e.g. Someone in Boston, MA USA wants intel map link for Massachusetts Institute of Technology (MIT for those of us who live near by). The first result returned by Google Geocode API for `MIT` is some place in Japan. The user must follow map link, which may take some time to load if on mobile, before realizing it is not the result they were looking for.

> drstevens [8:09 PM] 
> sambot intelmap mit

> sambot BOT [8:09 PM] 
> drstevens: https://www.ingress.com/intel?ll=36.3658556,140.4712215&z=16

This commit includes the address from the geocode response with the intelmap link in the hubot response.

> drstevens [7:55 PM] 
> sambot intelmap mit

> sambot BOT [7:55 PM] 
> Mito, Ibaraki Prefecture, Japan
> https://www.ingress.com/intel?ll=36.3658556,140.4712215&z=16

My original solution was to return links for all results from the Geocode API for those people who live in  Boston, KY (see https://github.com/drstevens/hubot-ingress/commit/11b8e25eb1fb0030213b369edb55db250341bd87), but feedback I got was that it was too verbose. I instead just took the first response.

> sambot BOT [7:33 PM] 
> https://www.ingress.com/intel?ll=42.3600825,-71.0588801&z=16
> Boston, IN, USA
> https://www.ingress.com/intel?ll=39.74116009999999,-84.8519034&z=16
> Boston, GA 31626, USA
> https://www.ingress.com/intel?ll=30.7918613,-83.78988679999999&z=16
> Boston, KY 40107, USA
> https://www.ingress.com/intel?ll=37.787563,-85.6727374&z=16
> Boston, NY 14025, USA
> https://www.ingress.com/intel?ll=42.6289495,-78.7375289&z=16
> Boston, VA 22713, USA
> https://www.ingress.com/intel?ll=38.5421671,-78.1322733&z=16