### PR TITLE
Add listeners to calculate checkpoint times for a specific day/date

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ next X start times.
 
 `hubot checkpoint|cp [count]`
 
+### Get Checkpoint times on a day
+
+Calculate the checkpoint times for a given day. Day given can be in common date formats (e.g. 5/17/14, May 4, 1999, 5 May 2016) and in English day names (e.g. Saturday, monday, this Thursday). Note that "Thursday", "this Thursday", and "next Thursday" all return the same data.
+
+`hubot checkpoints|cps on <day>`
+
 ### Get Timezone Offset
 
 Returns the current configured timezone offset.

--- a/test/cycle-times-coffee.coffee
+++ b/test/cycle-times-coffee.coffee
@@ -27,7 +27,13 @@ describe 'ingress: cycle times', ->
     expect(@robot.respond).to.have.been.calledWith /(septi)?cycle\s*([0-9])?$/i
 
   it 'registers "checkpoint" listener', ->
-    expect(@robot.respond).to.have.been.calledWith /c(heck)?p(oint)?\s*([0-9])?/i
+    expect(@robot.respond).to.have.been.calledWith /c(heck)?p(oint)?(\s+[0-9]+)?$/i
+
+  it 'registers "checkpoints on day" listener', ->
+    expect(@robot.respond).to.have.been.calledWith /c(heck)?p(oint)?s\s+on\s+((this|next)\s+)?([a-z]+day)/i
+
+  it 'registers "checkpoints on date" listener', ->
+    expect(@robot.respond).to.have.been.calledWith /c(heck)?p(oint)?s on (.*)/i
 
   it 'registers "cycle offset" listener', ->
     expect(@robot.respond).to.have.been.calledWith /cycle offset/i

--- a/test/cycle-times-test.coffee
+++ b/test/cycle-times-test.coffee
@@ -1,6 +1,7 @@
 chai = require 'chai'
 sinon = require 'sinon'
 chai.use require 'sinon-chai'
+moment = require 'moment-timezone'
 
 expect = chai.expect
 
@@ -21,6 +22,7 @@ describe 'ingress: cycle times', ->
         user:
           @user
 
+  process.env.HUBOT_CYCLE_TZ_NAME = 'UTC'
   require("../src/cycle-times")(robot)
 
   it 'registers "cycle" listener', ->
@@ -31,6 +33,26 @@ describe 'ingress: cycle times', ->
 
   it 'registers "checkpoints on day" listener', ->
     expect(@robot.respond).to.have.been.calledWith /c(heck)?p(oint)?s\s+on\s+((this|next)\s+)?([a-z]+day)/i
+
+  it 'responds to "checkpoints on 12/25/13"', ->
+    @msg.match = [0, 1, 2, '12/25/2013']
+    @robot.respond.args[6][1](@msg)
+
+    expect(@msg.send).to.have.been.calledWith sinon.match /^.*December 25th 2013.*4am, 9am, 2pm, 7pm, 12am\./i
+
+  it 'responds to "checkpoints on Saturday"', ->
+    @msg.match = [0, 1, 2, 3, 4, 'saturday']
+    @robot.respond.args[5][1](@msg)
+    today = moment().startOf 'day'
+    saturday = moment().day('saturday').startOf 'day'
+    saturday.add 7, "days" unless saturday.isAfter today
+    realDate = saturday.format 'YYYY-MM-DD'
+    otherMsg =
+      send: sinon.spy()
+      match: [0, 1, 2, realDate]
+
+    @robot.respond.args[6][1](otherMsg)
+    expect(@msg.send).to.have.been.calledWith otherMsg.send.args[0][0]
 
   it 'registers "checkpoints on date" listener', ->
     expect(@robot.respond).to.have.been.calledWith /c(heck)?p(oint)?s on (.*)/i


### PR DESCRIPTION
As the title says. Allows `hubot cps on Sunday` to get all checkpoints on the upcoming Sunday.