### PR TITLE
Add intelmap -> Google Map translation

### DIFF
--- a/src/intel-map.coffee
+++ b/src/intel-map.coffee
@@ -9,6 +9,7 @@
 #
 # Commands:
 #   hubot intelmap for <search>
+#   https://www.ingress.com/intel?ll=<lat>,<lng> - Return Google Maps image and link for intelmap location
 #
 
 module.exports = (robot) ->
@@ -41,6 +42,25 @@ module.exports = (robot) ->
     url = intelmapUrl result
     msg.send url
 
+  gmapImageUrl = (latlng) ->
+    return "https://maps.googleapis.com/maps/api/staticmap?center=" + latlng + "&size=400x300&zoom=15&markers=" + latlng
+
+  sendGmapImageLink = (msg, result) ->
+    url = gmapImageUrl result
+    msg.send url
+
+  gmapLink = (latlng) ->
+    return "https://maps.google.com/maps?ll=" + latlng + "&q=" + latlng
+
+  sendGmapLink = (msg, result) ->
+    url = gmapLink result
+    return msg.send url
+
   robot.respond /(intelmap|intel map)(?: for)?\s(.*)/i, (msg) ->
     location = msg.match[2]
     lookupLatLong msg, location, sendIntelLink
+
+  robot.hear /https:\/\/www.ingress.com\/intel\?ll=(-?\d+\.\d+,-?\d+\.\d+)/, (msg) ->
+    latlng = msg.match[1]
+    sendGmapImageLink msg, latlng
+    sendGmapLink msg, latlng

--- a/src/intel-map.coffee
+++ b/src/intel-map.coffee
@@ -9,7 +9,7 @@
 #
 # Commands:
 #   hubot intelmap for <search>
-#   https://www.ingress.com/intel?ll=<lat>,<lng> - Return Google Maps image and link for intelmap location
+#   ingress.com/intel?ll=<lat>,<lng> - Return Google Maps image and link for intelmap location
 #
 
 module.exports = (robot) ->
@@ -60,7 +60,7 @@ module.exports = (robot) ->
     location = msg.match[2]
     lookupLatLong msg, location, sendIntelLink
 
-  robot.hear /https:\/\/www.ingress.com\/intel\?ll=(-?\d+\.\d+,-?\d+\.\d+)/, (msg) ->
+  robot.hear /ingress.com\/intel\?ll=(-?\d+\.\d+,-?\d+\.\d+)/, (msg) ->
     latlng = msg.match[1]
     sendGmapImageLink msg, latlng
     sendGmapLink msg, latlng


### PR DESCRIPTION
Hubot will listen for someone to post an intel map link, and respond with a Google Maps static image of the location and a Google Maps link.

```
Someone> https://www.ingress.com/intel?ll=30.318951,-97.7948&z=10
Hubot> https://maps.googleapis.com/maps/api/staticmap?center=30.318951,-97.7948&size=400x300&zoom=15&markers=30.318951,-97.7948
Hubot> https://maps.google.com/maps?ll=30.318951,-97.7948&q=30.318951,-97.7948
```
