### PR TITLE
Add contrib rules

### DIFF
--- a/contributing.json
+++ b/contributing.json
@@ -1,0 +1,36 @@
+{
+  "commit": {
+    "subject_cannot_be_empty": true,
+    "subject_must_be_longer_than": 6,
+    "subject_must_be_shorter_than": 101,
+    "subject_lines_must_be_shorter_than": 51,
+    "subject_must_be_single_line": true,
+    "subject_must_be_in_case": "lower",
+    "subject_must_be_in_tense": "imperative",
+    "subject_must_start_with_case": "lower",
+    "subject_must_not_end_with_dot": true,
+    "body_lines_must_be_shorter_than": 73
+  },
+  "pull_request": {
+    "subject_cannot_be_empty": true,
+    "subject_must_be_longer_than": 6,
+    "subject_must_be_shorter_than": 101,
+    "subject_must_be_in_tense": "imperative",
+    "subject_must_start_with_case": "upper",
+    "subject_must_not_end_with_dot": true,
+    "body_cannot_be_empty": true
+  },
+  "issue": {
+    "subject_cannot_be_empty": true,
+    "subject_must_be_longer_than": 6,
+    "subject_must_be_shorter_than": 101,
+    "subject_must_be_in_tense": "imperative",
+    "subject_must_start_with_case": "upper",
+    "subject_must_not_end_with_dot": true,
+    "body_cannot_be_empty": true,
+    "body_must_include_reproduction_steps": [
+      "bug"
+    ],
+    "label_must_be_set": true
+  }
+}


### PR DESCRIPTION
Here is my idea of what contrib rules should be automatically handled by GitMagic.

Unfortunately there's no rule for catching changes to the package.json version entry, so we'll still need to keep an eye out for that.